### PR TITLE
Fix so semver wth a dash works

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
 
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
@@ -48,11 +50,11 @@ jobs:
         repo: pulumi/pulumictl
 
     - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)" >> $GITHUB_ENV
+      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic --omit-commit-hash)" >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v5
       with:
-        args: -p 3 release --rm-dist
+        args: -p 3 release --clean
         version: latest
 
     strategy:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -16,14 +16,19 @@ builds:
       - darwin
       - windows
       - linux
+    hooks:
+      post:
+      - env GOOS={{ .Os }} GOARCH={{ .Arch }} go clean -cache
+      - env GOOS={{ .Os }} GOARCH={{ .Arch }} go clean -modcache
+    ignore: []
     ldflags:
       # The line below MUST align with the module in current provider/go.mod
       - -X github.com/Twingate/pulumi-twingate/provider/pkg/version.Version={{.Tag }}
     main: ./cmd/pulumi-resource-twingate/
 changelog:
-  skip: true
+  disable: true
 release:
   disable: false
-  prerelease: auto
 snapshot:
   name_template: '{{ .Tag }}-SNAPSHOT'
+project_name: "pulumi-twingate"

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ VERSION_PATH     := ${PROVIDER_PATH}/pkg/version.Version
 
 TFGEN           := pulumi-tfgen-${PACK}
 PROVIDER        := pulumi-resource-${PACK}
-VERSION         := $(shell pulumictl get version)
+VERSION         := $(shell pulumictl get version --omit-commit-hash)
 
 TESTPARALLELISM := 4
 
@@ -57,7 +57,7 @@ provider:: tfgen install_plugins # build the provider binary
 
 build_sdks:: install_plugins provider build_nodejs build_python build_go build_dotnet # build all the sdks
 
-build_nodejs:: VERSION := $(shell pulumictl get version --language javascript)
+build_nodejs:: VERSION := $(shell pulumictl get version --language javascript --omit-commit-hash)
 build_nodejs:: install_plugins tfgen # build the node sdk
 	$(WORKING_DIR)/bin/$(TFGEN) nodejs --overlays provider/overlays/nodejs --out sdk/nodejs/
 	cd sdk/nodejs/ && \
@@ -66,7 +66,7 @@ build_nodejs:: install_plugins tfgen # build the node sdk
         cp ../../README.md ../../LICENSE package.json yarn.lock ./bin/ && \
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
-build_python:: PYPI_VERSION := $(shell pulumictl get version --language python)
+build_python:: PYPI_VERSION := $(shell pulumictl get version --language python --omit-commit-hash)
 build_python:: install_plugins tfgen # build the python sdk
 	$(WORKING_DIR)/bin/$(TFGEN) python --overlays provider/overlays/python --out sdk/python/
 	cd sdk/python/ && \
@@ -77,9 +77,9 @@ build_python:: install_plugins tfgen # build the python sdk
         rm ./bin/setup.py.bak && \
         cd ./bin && python3 setup.py build sdist
 
-build_dotnet:: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
+build_dotnet:: DOTNET_VERSION := $(shell pulumictl get version --language dotnet --omit-commit-hash)
 build_dotnet:: install_plugins tfgen # build the dotnet sdk
-	pulumictl get version --language dotnet
+	pulumictl get version --language dotnet --omit-commit-hash
 	$(WORKING_DIR)/bin/$(TFGEN) dotnet --overlays provider/overlays/dotnet --out sdk/dotnet/
 	cd sdk/dotnet/ && \
 		echo "${DOTNET_VERSION}" >version.txt && \


### PR DESCRIPTION
Fix so that versions with dashes work. Versions were being generated by `pulumictl get version`. A commit has was being added that caused a "was not made against commit" Adding --omit-commit-hash fixed it

Fix goreleaser deprecation notices