### PR TITLE
Change pulumictl get version --language for python to generic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ build_nodejs:: install_plugins tfgen # build the node sdk
         cp ../../README.md ../../LICENSE package.json yarn.lock ./bin/ && \
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 
-build_python:: PYPI_VERSION := $(shell pulumictl get version --language python --omit-commit-hash)
+build_python:: PYPI_VERSION := $(shell pulumictl get version --language generic --omit-commit-hash)
 build_python:: install_plugins tfgen # build the python sdk
 	$(WORKING_DIR)/bin/$(TFGEN) python --overlays provider/overlays/python --out sdk/python/
 	cd sdk/python/ && \


### PR DESCRIPTION
pulumictl get version --language python adds a "0" at the end of the release name. See code at https://github.com/pulumi/pulumictl/blob/cb201f712f800a0ec17b32967d24ae3c6a151412/pkg/gitversion/gitversion.go#L100

This later causes a pulumi error:
```
    error: Could not automatically download and install resource plugin 'pulumi-resource-twingate' at version v2.1.2-dev.0, install the plugin using `pulumi plugin install resource twingate v2.1.2-dev.0 --server github://api.github.com/Twingate/pulumi-twingate`: error downloading provider twingate to file: failed to download plugin: twingate-2.1.2-dev.0: 404 HTTP error fetching plugin from https://api.github.com/repos/Twingate/pulumi-twingate/releases/tags/v2.1.2-dev.0. If this is a private GitHub repository, try providing a token via the GITHUB_TOKEN environment variable. See: https://github.com/settings/tokens
```

The version v2.1.2-dev.0 can't be automatically downloaded because the published release is v2.1.2-dev

