### PR TITLE
Add temporary GOMODCACHE directory

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,10 @@ jobs:
 
     - name: Set PreRelease Version
       run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic --omit-commit-hash)" >> $GITHUB_ENV
+
+    - name: Set temporary GOMODCACHE
+      run: echo "GOMODCACHE=$(mktemp -d)" >> $GITHUB_ENV
+
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v6
       with:


### PR DESCRIPTION
Hoping to fix this build error  https://github.com/Twingate/pulumi-twingate/actions/runs/12952032935/job/36129248602

```
⨯ release failed after 7m15s               error=post hook failed: shell: 'env GOOS=darwin GOARCH=arm64 go clean -modcache': exit status 1: go: unlinkat /home/runner/go/pkg/mod: directory not empty
```

## Changes
- Add temporary GOMODCACHE directory
