### PR TITLE
remove post build hooks for goreleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -17,9 +17,7 @@ builds:
       - windows
       - linux
     hooks:
-      post:
-      - env GOOS={{ .Os }} GOARCH={{ .Arch }} go clean -cache
-      - env GOOS={{ .Os }} GOARCH={{ .Arch }} go clean -modcache
+      post: []
     ignore: []
     ldflags:
       # The line below MUST align with the module in current provider/go.mod


### PR DESCRIPTION
## Changes
- Removing post hook clean up.  GitHub-hosted runners are short lived and ephemeral so this is not needed
