### PR TITLE
DEV-2721 | Remove unused dependabot dir

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -53,14 +53,3 @@ updates:
     commit-message:
       prefix: "chore"
       include: "scope"
-  - package-ecosystem: "gomod"
-    directory: "/sdk/go/twingate"
-    schedule:
-      interval: "weekly"
-      time: "08:00"
-      day: "sunday"
-    labels:
-      - "dependencies"
-    commit-message:
-      prefix: "chore"
-      include: "scope"


### PR DESCRIPTION
Clean up. There is no longer a go.mod file in that directory 
