### PR TITLE
Add automated SDK version tagging to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -165,3 +165,30 @@ jobs:
           - python
           - dotnet
           - go
+
+  create_sdk_tag:
+    name: Create SDK Tag
+    runs-on: ubuntu-latest
+    needs: publish_sdk
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Create and Push SDK Tag
+        run: |
+          # Extract version from tag (e.g., refs/tags/v3.5.1 -> v3.5.1)
+          VERSION=${GITHUB_REF#refs/tags/}
+
+          echo "Creating SDK tag for version: $VERSION"
+
+          # Create SDK tag pointing to the same commit as the main tag
+          git tag "sdk/$VERSION"
+
+          # Push SDK tag
+          git push origin "sdk/$VERSION"
+
+          echo "✅ Created and pushed tag: sdk/$VERSION"

--- a/examples/go/go.mod
+++ b/examples/go/go.mod
@@ -3,13 +3,12 @@ module twingate_go_example
 go 1.24.0
 
 require (
-	// uncomment the following line to use the remote version of the sdk
-	github.com/Twingate/pulumi-twingate/sdk/v3 v3.0.0-20250223083426-375c59fb5a8e
+	github.com/Twingate/pulumi-twingate/sdk/v3 v3.0.0-20250922175542-8f7b9e56d4a5
 	github.com/pulumi/pulumi/sdk/v3 v3.207.0
 )
 
-// Use local SDK since Go module
-replace github.com/Twingate/pulumi-twingate/sdk/v3 => ../../sdk
+// Uncomment to use local SDK for development/testing
+// replace github.com/Twingate/pulumi-twingate/sdk/v3 => ../../sdk
 
 require (
 	dario.cat/mergo v1.0.1 // indirect

--- a/examples/go/go.sum
+++ b/examples/go/go.sum
@@ -9,8 +9,8 @@ github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERo
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/ProtonMail/go-crypto v1.1.6 h1:ZcV+Ropw6Qn0AX9brlQLAUXfqLBc7Bl+f/DmNxpLfdw=
 github.com/ProtonMail/go-crypto v1.1.6/go.mod h1:rA3QumHc/FZ8pAHreoekgiAbzpNsfQAosU5td4SnOrE=
-github.com/Twingate/pulumi-twingate/sdk/v3 v3.0.0-20250223083426-375c59fb5a8e h1:2J0Uz1yN8upeKa7r4dRzAuNh2MQ25r86eIQSOlX/J1A=
-github.com/Twingate/pulumi-twingate/sdk/v3 v3.0.0-20250223083426-375c59fb5a8e/go.mod h1:2r6VdyZKFdgd/Ru5XZK7kS1QgFHJp90CVSU0mxHXuNo=
+github.com/Twingate/pulumi-twingate/sdk/v3 v3.0.0-20250922175542-8f7b9e56d4a5 h1:SC2VmwTL9mzlbGj63dx7do0NNEJaKWoh+6RISTih+nk=
+github.com/Twingate/pulumi-twingate/sdk/v3 v3.0.0-20250922175542-8f7b9e56d4a5/go.mod h1:ZI/bzYIl8FglFzhotrU2kJ5wZmCoAsKWmVZakIVJLQM=
 github.com/agext/levenshtein v1.2.3 h1:YB2fHEn0UJagG8T1rrWknE3ZQzWM06O8AMAatNn7lmo=
 github.com/agext/levenshtein v1.2.3/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be h1:9AeTilPcZAjCFIImctFaOjnTIavg87rW78vTPkQqLI8=


### PR DESCRIPTION
## Summary
Automates the creation of proper SDK version tags during releases, replacing pseudo-versions with clean semantic versions.

## Changes
- **Added `create_sdk_tag` job to `.github/workflows/release.yml`**
  - Runs after `publish_sdk` job completes
  - Automatically creates `sdk/vX.Y.Z` tag pointing to same commit as release tag
  - Enables Go modules to use clean versions like `v3.5.1` instead of pseudo-versions like `v3.0.0-20250922175542-8f7b9e56d4a5`

- **Updated `examples/go/go.mod`**
  - Now uses published version `v3.5.0` with proper pseudo-version
  - Removed local SDK replacement (was for testing only)
  - Added comment explaining how to use local SDK for development

## How It Works

### Before (Manual Process)
1. Release v3.5.1
2. Manually calculate pseudo-version timestamp and commit hash
3. Update examples with complex version: `v3.0.0-20250922175542-8f7b9e56d4a5`

### After (Automated)
1. Release v3.5.1
2. GitHub Actions automatically creates `sdk/v3.5.1` tag
3. Update examples with clean version: `v3.5.1`

## Benefits
- **Clean semantic versioning** - No more complex pseudo-versions
- **Better user experience** - Users can reference versions like `v3.5.1`
- **Fully automated** - No manual tag creation needed
- **Zero breaking changes** - Backward compatible with existing releases

## Testing
The workflow will be tested on the next release. To verify:
```bash
# After releasing v3.5.1
git fetch --tags
git tag -l | grep "3.5.1"
# Should show both: v3.5.1 and sdk/v3.5.1

go get github.com/Twingate/pulumi-twingate/sdk/v3@v3.5.1
# Should work without errors
```

Generated with [Claude Code](https://claude.com/claude-code)