### PR TITLE
Fix persistent diff on tags_all

### DIFF
--- a/provider/cmd/pulumi-resource-twingate/schema.json
+++ b/provider/cmd/pulumi-resource-twingate/schema.json
@@ -532,7 +532,7 @@
                 },
                 "mode": {
                     "type": "string",
-                    "description": "This will set the\u003cspan pulumi-lang-nodejs=\" accessPolicy \" pulumi-lang-dotnet=\" AccessPolicy \" pulumi-lang-go=\" accessPolicy \" pulumi-lang-python=\" access_policy \" pulumi-lang-yaml=\" accessPolicy \" pulumi-lang-java=\" accessPolicy \"\u003e access_policy \u003c/span\u003emode on the edge. The valid values are `MANUAL`, `AUTO_LOCK` and `ACCESS_REQUEST`.\n"
+                    "description": "This will set the\u003cspan pulumi-lang-nodejs=\" accessPolicy \" pulumi-lang-dotnet=\" AccessPolicy \" pulumi-lang-go=\" accessPolicy \" pulumi-lang-python=\" access_policy \" pulumi-lang-yaml=\" accessPolicy \" pulumi-lang-java=\" accessPolicy \"\u003e accessPolicy \u003c/span\u003emode on the edge. The valid values are `MANUAL`, `AUTO_LOCK` and `ACCESS_REQUEST`.\n"
                 }
             },
             "type": "object",
@@ -558,7 +558,7 @@
                 },
                 "mode": {
                     "type": "string",
-                    "description": "This will set the\u003cspan pulumi-lang-nodejs=\" accessPolicy \" pulumi-lang-dotnet=\" AccessPolicy \" pulumi-lang-go=\" accessPolicy \" pulumi-lang-python=\" access_policy \" pulumi-lang-yaml=\" accessPolicy \" pulumi-lang-java=\" accessPolicy \"\u003e access_policy \u003c/span\u003emode on the edge. The valid values are `MANUAL`, `AUTO_LOCK` and `ACCESS_REQUEST`.\n"
+                    "description": "This will set the\u003cspan pulumi-lang-nodejs=\" accessPolicy \" pulumi-lang-dotnet=\" AccessPolicy \" pulumi-lang-go=\" accessPolicy \" pulumi-lang-python=\" access_policy \" pulumi-lang-yaml=\" accessPolicy \" pulumi-lang-java=\" accessPolicy \"\u003e accessPolicy \u003c/span\u003emode on the edge. The valid values are `MANUAL`, `AUTO_LOCK` and `ACCESS_REQUEST`.\n"
                 }
             },
             "type": "object",

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -110,7 +110,15 @@ func Provider() bridgev3.ProviderInfo {
 			"twingate_dns_filtering_profile": {Tok: bridgev3.MakeResource(mainPkg, mainMod, "TwingateDNSFilteringProfile")},
 			"twingate_group":                 {Tok: bridgev3.MakeResource(mainPkg, mainMod, "TwingateGroup")},
 			"twingate_remote_network":        {Tok: bridgev3.MakeResource(mainPkg, mainMod, "TwingateRemoteNetwork")},
-			"twingate_resource":              {Tok: bridgev3.MakeResource(mainPkg, mainMod, "TwingateResource")},
+			"twingate_resource": {
+				Tok: bridgev3.MakeResource(mainPkg, mainMod, "TwingateResource"),
+				Fields: map[string]*bridgev3.SchemaInfo{
+					// Terraform exposes tags_all as Optional+Computed, which causes perpetual diffs
+					// once provider-level default tags are merged into state. Force it back to
+					// computed-only on the Pulumi side.
+					"tags_all": {MarkAsOptional: bridgev3.False()},
+				},
+			},
 			"twingate_service_account":       {Tok: bridgev3.MakeResource(mainPkg, mainMod, "TwingateServiceAccount")},
 			"twingate_service_account_key":   {Tok: bridgev3.MakeResource(mainPkg, mainMod, "TwingateServiceAccountKey")},
 			"twingate_user":                  {Tok: bridgev3.MakeResource(mainPkg, mainMod, "TwingateUser")},

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -150,14 +150,12 @@ For other platforms, see the [act installation guide](https://github.com/nektos/
 To test a specific workflow job, use:
 
 ```bash
+# List all available jobs
+act --list
+
 # Test the lint workflow
 act pull_request -j lint
 
-# Test all pull request workflows
-act pull_request
-
-# Test push workflows
-act push
 ```
 
 **Note:** The first time you run `act`, it will ask you to choose a Docker image size. Select "Medium" for most workflows.

--- a/sdk/python/pulumi_twingate/_inputs.py
+++ b/sdk/python/pulumi_twingate/_inputs.py
@@ -65,28 +65,23 @@ __all__ = [
     'GetTwingateResourceProtocolsUdpArgsDict',
 ]
 
-MYPY = False
-
-if not MYPY:
-    class ProviderCacheArgsDict(TypedDict):
-        groups_enabled: NotRequired[pulumi.Input[_builtins.bool]]
-        """
-        Specifies whether the provider should cache groups. The default value is `true`.
-        """
-        groups_filter: NotRequired[pulumi.Input['ProviderCacheGroupsFilterArgsDict']]
-        """
-        Specifies the filter for the groups to be cached.
-        """
-        resource_enabled: NotRequired[pulumi.Input[_builtins.bool]]
-        """
-        Specifies whether the provider should cache resources. The default value is `true`.
-        """
-        resources_filter: NotRequired[pulumi.Input['ProviderCacheResourcesFilterArgsDict']]
-        """
-        Specifies the filter for the resources to be cached.
-        """
-elif False:
-    ProviderCacheArgsDict: TypeAlias = Mapping[str, Any]
+class ProviderCacheArgsDict(TypedDict):
+    groups_enabled: NotRequired[pulumi.Input[_builtins.bool]]
+    """
+    Specifies whether the provider should cache groups. The default value is `true`.
+    """
+    groups_filter: NotRequired[pulumi.Input['ProviderCacheGroupsFilterArgsDict']]
+    """
+    Specifies the filter for the groups to be cached.
+    """
+    resource_enabled: NotRequired[pulumi.Input[_builtins.bool]]
+    """
+    Specifies whether the provider should cache resources. The default value is `true`.
+    """
+    resources_filter: NotRequired[pulumi.Input['ProviderCacheResourcesFilterArgsDict']]
+    """
+    Specifies the filter for the resources to be cached.
+    """
 
 @pulumi.input_type
 class ProviderCacheArgs:
@@ -159,42 +154,39 @@ class ProviderCacheArgs:
         pulumi.set(self, "resources_filter", value)
 
 
-if not MYPY:
-    class ProviderCacheGroupsFilterArgsDict(TypedDict):
-        is_active: NotRequired[pulumi.Input[_builtins.bool]]
-        """
-        Returns only Groups matching the specified state.
-        """
-        name: NotRequired[pulumi.Input[_builtins.str]]
-        """
-        Returns only groups that exactly match this name. If no options are passed it will return all resources. Only one option can be used at a time.
-        """
-        name_contains: NotRequired[pulumi.Input[_builtins.str]]
-        """
-        Match when the value exist in the name of the group.
-        """
-        name_exclude: NotRequired[pulumi.Input[_builtins.str]]
-        """
-        Match when the exact value does not exist in the name of the group.
-        """
-        name_prefix: NotRequired[pulumi.Input[_builtins.str]]
-        """
-        The name of the group must start with the value.
-        """
-        name_regexp: NotRequired[pulumi.Input[_builtins.str]]
-        """
-        The regular expression match of the name of the group.
-        """
-        name_suffix: NotRequired[pulumi.Input[_builtins.str]]
-        """
-        The name of the group must end with the value.
-        """
-        types: NotRequired[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]]
-        """
-        Returns groups that match a list of types. valid types: `MANUAL`, `SYNCED`, `SYSTEM`.
-        """
-elif False:
-    ProviderCacheGroupsFilterArgsDict: TypeAlias = Mapping[str, Any]
+class ProviderCacheGroupsFilterArgsDict(TypedDict):
+    is_active: NotRequired[pulumi.Input[_builtins.bool]]
+    """
+    Returns only Groups matching the specified state.
+    """
+    name: NotRequired[pulumi.Input[_builtins.str]]
+    """
+    Returns only groups that exactly match this name. If no options are passed it will return all resources. Only one option can be used at a time.
+    """
+    name_contains: NotRequired[pulumi.Input[_builtins.str]]
+    """
+    Match when the value exist in the name of the group.
+    """
+    name_exclude: NotRequired[pulumi.Input[_builtins.str]]
+    """
+    Match when the exact value does not exist in the name of the group.
+    """
+    name_prefix: NotRequired[pulumi.Input[_builtins.str]]
+    """
+    The name of the group must start with the value.
+    """
+    name_regexp: NotRequired[pulumi.Input[_builtins.str]]
+    """
+    The regular expression match of the name of the group.
+    """
+    name_suffix: NotRequired[pulumi.Input[_builtins.str]]
+    """
+    The name of the group must end with the value.
+    """
+    types: NotRequired[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]]
+    """
+    Returns groups that match a list of types. valid types: `MANUAL`, `SYNCED`, `SYSTEM`.
+    """
 
 @pulumi.input_type
 class ProviderCacheGroupsFilterArgs:
@@ -331,38 +323,35 @@ class ProviderCacheGroupsFilterArgs:
         pulumi.set(self, "types", value)
 
 
-if not MYPY:
-    class ProviderCacheResourcesFilterArgsDict(TypedDict):
-        name: NotRequired[pulumi.Input[_builtins.str]]
-        """
-        Returns only resources that exactly match this name. If no options are passed it will return all resources. Only one option can be used at a time.
-        """
-        name_contains: NotRequired[pulumi.Input[_builtins.str]]
-        """
-        Match when the value exist in the name of the resource.
-        """
-        name_exclude: NotRequired[pulumi.Input[_builtins.str]]
-        """
-        Match when the exact value does not exist in the name of the resource.
-        """
-        name_prefix: NotRequired[pulumi.Input[_builtins.str]]
-        """
-        The name of the resource must start with the value.
-        """
-        name_regexp: NotRequired[pulumi.Input[_builtins.str]]
-        """
-        The regular expression match of the name of the resource.
-        """
-        name_suffix: NotRequired[pulumi.Input[_builtins.str]]
-        """
-        The name of the resource must end with the value.
-        """
-        tags: NotRequired[pulumi.Input[Mapping[str, pulumi.Input[_builtins.str]]]]
-        """
-        Returns only resources that exactly match the given tags.
-        """
-elif False:
-    ProviderCacheResourcesFilterArgsDict: TypeAlias = Mapping[str, Any]
+class ProviderCacheResourcesFilterArgsDict(TypedDict):
+    name: NotRequired[pulumi.Input[_builtins.str]]
+    """
+    Returns only resources that exactly match this name. If no options are passed it will return all resources. Only one option can be used at a time.
+    """
+    name_contains: NotRequired[pulumi.Input[_builtins.str]]
+    """
+    Match when the value exist in the name of the resource.
+    """
+    name_exclude: NotRequired[pulumi.Input[_builtins.str]]
+    """
+    Match when the exact value does not exist in the name of the resource.
+    """
+    name_prefix: NotRequired[pulumi.Input[_builtins.str]]
+    """
+    The name of the resource must start with the value.
+    """
+    name_regexp: NotRequired[pulumi.Input[_builtins.str]]
+    """
+    The regular expression match of the name of the resource.
+    """
+    name_suffix: NotRequired[pulumi.Input[_builtins.str]]
+    """
+    The name of the resource must end with the value.
+    """
+    tags: NotRequired[pulumi.Input[Mapping[str, pulumi.Input[_builtins.str]]]]
+    """
+    Returns only resources that exactly match the given tags.
+    """
 
 @pulumi.input_type
 class ProviderCacheResourcesFilterArgs:
@@ -483,14 +472,11 @@ class ProviderCacheResourcesFilterArgs:
         pulumi.set(self, "tags", value)
 
 
-if not MYPY:
-    class ProviderDefaultTagsArgsDict(TypedDict):
-        tags: NotRequired[pulumi.Input[Mapping[str, pulumi.Input[_builtins.str]]]]
-        """
-        A map of key-value pair tags to be set on all resources by default.
-        """
-elif False:
-    ProviderDefaultTagsArgsDict: TypeAlias = Mapping[str, Any]
+class ProviderDefaultTagsArgsDict(TypedDict):
+    tags: NotRequired[pulumi.Input[Mapping[str, pulumi.Input[_builtins.str]]]]
+    """
+    A map of key-value pair tags to be set on all resources by default.
+    """
 
 @pulumi.input_type
 class ProviderDefaultTagsArgs:
@@ -515,18 +501,15 @@ class ProviderDefaultTagsArgs:
         pulumi.set(self, "tags", value)
 
 
-if not MYPY:
-    class TwingateDNSFilteringProfileAllowedDomainsArgsDict(TypedDict):
-        domains: NotRequired[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]]
-        """
-        A set of allowed domains. Defaults to an empty set.
-        """
-        is_authoritative: NotRequired[pulumi.Input[_builtins.bool]]
-        """
-        Whether Terraform should override changes made outside of Terraform. Defaults to true.
-        """
-elif False:
-    TwingateDNSFilteringProfileAllowedDomainsArgsDict: TypeAlias = Mapping[str, Any]
+class TwingateDNSFilteringProfileAllowedDomainsArgsDict(TypedDict):
+    domains: NotRequired[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]]
+    """
+    A set of allowed domains. Defaults to an empty set.
+    """
+    is_authoritative: NotRequired[pulumi.Input[_builtins.bool]]
+    """
+    Whether Terraform should override changes made outside of Terraform. Defaults to true.
+    """
 
 @pulumi.input_type
 class TwingateDNSFilteringProfileAllowedDomainsArgs:
@@ -567,46 +550,43 @@ class TwingateDNSFilteringProfileAllowedDomainsArgs:
         pulumi.set(self, "is_authoritative", value)
 
 
-if not MYPY:
-    class TwingateDNSFilteringProfileContentCategoriesArgsDict(TypedDict):
-        block_adult_content: NotRequired[pulumi.Input[_builtins.bool]]
-        """
-        Whether to block adult content. Defaults to false.
-        """
-        block_dating: NotRequired[pulumi.Input[_builtins.bool]]
-        """
-        Whether to block dating content. Defaults to false.
-        """
-        block_gambling: NotRequired[pulumi.Input[_builtins.bool]]
-        """
-        Whether to block gambling content. Defaults to false.
-        """
-        block_games: NotRequired[pulumi.Input[_builtins.bool]]
-        """
-        Whether to block games. Defaults to false.
-        """
-        block_piracy: NotRequired[pulumi.Input[_builtins.bool]]
-        """
-        Whether to block piracy sites. Defaults to false.
-        """
-        block_social_media: NotRequired[pulumi.Input[_builtins.bool]]
-        """
-        Whether to block social media. Defaults to false.
-        """
-        block_streaming: NotRequired[pulumi.Input[_builtins.bool]]
-        """
-        Whether to block streaming content. Defaults to false.
-        """
-        enable_safesearch: NotRequired[pulumi.Input[_builtins.bool]]
-        """
-        Whether to force safe search. Defaults to false.
-        """
-        enable_youtube_restricted_mode: NotRequired[pulumi.Input[_builtins.bool]]
-        """
-        Whether to force YouTube to use restricted mode. Defaults to false.
-        """
-elif False:
-    TwingateDNSFilteringProfileContentCategoriesArgsDict: TypeAlias = Mapping[str, Any]
+class TwingateDNSFilteringProfileContentCategoriesArgsDict(TypedDict):
+    block_adult_content: NotRequired[pulumi.Input[_builtins.bool]]
+    """
+    Whether to block adult content. Defaults to false.
+    """
+    block_dating: NotRequired[pulumi.Input[_builtins.bool]]
+    """
+    Whether to block dating content. Defaults to false.
+    """
+    block_gambling: NotRequired[pulumi.Input[_builtins.bool]]
+    """
+    Whether to block gambling content. Defaults to false.
+    """
+    block_games: NotRequired[pulumi.Input[_builtins.bool]]
+    """
+    Whether to block games. Defaults to false.
+    """
+    block_piracy: NotRequired[pulumi.Input[_builtins.bool]]
+    """
+    Whether to block piracy sites. Defaults to false.
+    """
+    block_social_media: NotRequired[pulumi.Input[_builtins.bool]]
+    """
+    Whether to block social media. Defaults to false.
+    """
+    block_streaming: NotRequired[pulumi.Input[_builtins.bool]]
+    """
+    Whether to block streaming content. Defaults to false.
+    """
+    enable_safesearch: NotRequired[pulumi.Input[_builtins.bool]]
+    """
+    Whether to force safe search. Defaults to false.
+    """
+    enable_youtube_restricted_mode: NotRequired[pulumi.Input[_builtins.bool]]
+    """
+    Whether to force YouTube to use restricted mode. Defaults to false.
+    """
 
 @pulumi.input_type
 class TwingateDNSFilteringProfileContentCategoriesArgs:
@@ -759,18 +739,15 @@ class TwingateDNSFilteringProfileContentCategoriesArgs:
         pulumi.set(self, "enable_youtube_restricted_mode", value)
 
 
-if not MYPY:
-    class TwingateDNSFilteringProfileDeniedDomainsArgsDict(TypedDict):
-        domains: NotRequired[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]]
-        """
-        A set of denied domains. Defaults to an empty set.
-        """
-        is_authoritative: NotRequired[pulumi.Input[_builtins.bool]]
-        """
-        Whether Terraform should override changes made outside of Terraform. Defaults to true.
-        """
-elif False:
-    TwingateDNSFilteringProfileDeniedDomainsArgsDict: TypeAlias = Mapping[str, Any]
+class TwingateDNSFilteringProfileDeniedDomainsArgsDict(TypedDict):
+    domains: NotRequired[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]]
+    """
+    A set of denied domains. Defaults to an empty set.
+    """
+    is_authoritative: NotRequired[pulumi.Input[_builtins.bool]]
+    """
+    Whether Terraform should override changes made outside of Terraform. Defaults to true.
+    """
 
 @pulumi.input_type
 class TwingateDNSFilteringProfileDeniedDomainsArgs:
@@ -811,22 +788,19 @@ class TwingateDNSFilteringProfileDeniedDomainsArgs:
         pulumi.set(self, "is_authoritative", value)
 
 
-if not MYPY:
-    class TwingateDNSFilteringProfilePrivacyCategoriesArgsDict(TypedDict):
-        block_ads_and_trackers: NotRequired[pulumi.Input[_builtins.bool]]
-        """
-        Whether to block ads and trackers. Defaults to false.
-        """
-        block_affiliate_links: NotRequired[pulumi.Input[_builtins.bool]]
-        """
-        Whether to block affiliate links. Defaults to false.
-        """
-        block_disguised_trackers: NotRequired[pulumi.Input[_builtins.bool]]
-        """
-        Whether to block disguised third party trackers. Defaults to false.
-        """
-elif False:
-    TwingateDNSFilteringProfilePrivacyCategoriesArgsDict: TypeAlias = Mapping[str, Any]
+class TwingateDNSFilteringProfilePrivacyCategoriesArgsDict(TypedDict):
+    block_ads_and_trackers: NotRequired[pulumi.Input[_builtins.bool]]
+    """
+    Whether to block ads and trackers. Defaults to false.
+    """
+    block_affiliate_links: NotRequired[pulumi.Input[_builtins.bool]]
+    """
+    Whether to block affiliate links. Defaults to false.
+    """
+    block_disguised_trackers: NotRequired[pulumi.Input[_builtins.bool]]
+    """
+    Whether to block disguised third party trackers. Defaults to false.
+    """
 
 @pulumi.input_type
 class TwingateDNSFilteringProfilePrivacyCategoriesArgs:
@@ -883,46 +857,43 @@ class TwingateDNSFilteringProfilePrivacyCategoriesArgs:
         pulumi.set(self, "block_disguised_trackers", value)
 
 
-if not MYPY:
-    class TwingateDNSFilteringProfileSecurityCategoriesArgsDict(TypedDict):
-        block_cryptojacking: NotRequired[pulumi.Input[_builtins.bool]]
-        """
-        Whether to block cryptojacking sites. Defaults to true.
-        """
-        block_dns_rebinding: NotRequired[pulumi.Input[_builtins.bool]]
-        """
-        Blocks public DNS entries from returning private IP addresses. Defaults to true.
-        """
-        block_domain_generation_algorithms: NotRequired[pulumi.Input[_builtins.bool]]
-        """
-        Blocks DGA domains. Defaults to true.
-        """
-        block_idn_homoglyph: NotRequired[pulumi.Input[_builtins.bool]]
-        """
-        Whether to block homoglyph attacks. Defaults to true.
-        """
-        block_newly_registered_domains: NotRequired[pulumi.Input[_builtins.bool]]
-        """
-        Blocks newly registered domains. Defaults to true.
-        """
-        block_parked_domains: NotRequired[pulumi.Input[_builtins.bool]]
-        """
-        Block parked domains. Defaults to true.
-        """
-        block_typosquatting: NotRequired[pulumi.Input[_builtins.bool]]
-        """
-        Blocks typosquatted domains. Defaults to true.
-        """
-        enable_google_safe_browsing: NotRequired[pulumi.Input[_builtins.bool]]
-        """
-        Whether to use Google Safe browsing lists to block content. Defaults to true.
-        """
-        enable_threat_intelligence_feeds: NotRequired[pulumi.Input[_builtins.bool]]
-        """
-        Whether to filter content using threat intelligence feeds. Defaults to true.
-        """
-elif False:
-    TwingateDNSFilteringProfileSecurityCategoriesArgsDict: TypeAlias = Mapping[str, Any]
+class TwingateDNSFilteringProfileSecurityCategoriesArgsDict(TypedDict):
+    block_cryptojacking: NotRequired[pulumi.Input[_builtins.bool]]
+    """
+    Whether to block cryptojacking sites. Defaults to true.
+    """
+    block_dns_rebinding: NotRequired[pulumi.Input[_builtins.bool]]
+    """
+    Blocks public DNS entries from returning private IP addresses. Defaults to true.
+    """
+    block_domain_generation_algorithms: NotRequired[pulumi.Input[_builtins.bool]]
+    """
+    Blocks DGA domains. Defaults to true.
+    """
+    block_idn_homoglyph: NotRequired[pulumi.Input[_builtins.bool]]
+    """
+    Whether to block homoglyph attacks. Defaults to true.
+    """
+    block_newly_registered_domains: NotRequired[pulumi.Input[_builtins.bool]]
+    """
+    Blocks newly registered domains. Defaults to true.
+    """
+    block_parked_domains: NotRequired[pulumi.Input[_builtins.bool]]
+    """
+    Block parked domains. Defaults to true.
+    """
+    block_typosquatting: NotRequired[pulumi.Input[_builtins.bool]]
+    """
+    Blocks typosquatted domains. Defaults to true.
+    """
+    enable_google_safe_browsing: NotRequired[pulumi.Input[_builtins.bool]]
+    """
+    Whether to use Google Safe browsing lists to block content. Defaults to true.
+    """
+    enable_threat_intelligence_feeds: NotRequired[pulumi.Input[_builtins.bool]]
+    """
+    Whether to filter content using threat intelligence feeds. Defaults to true.
+    """
 
 @pulumi.input_type
 class TwingateDNSFilteringProfileSecurityCategoriesArgs:
@@ -1075,22 +1046,19 @@ class TwingateDNSFilteringProfileSecurityCategoriesArgs:
         pulumi.set(self, "enable_threat_intelligence_feeds", value)
 
 
-if not MYPY:
-    class TwingateResourceAccessGroupArgsDict(TypedDict):
-        access_policies: NotRequired[pulumi.Input[Sequence[pulumi.Input['TwingateResourceAccessGroupAccessPolicyArgsDict']]]]
-        """
-        Restrict access according to JIT access policy
-        """
-        group_id: NotRequired[pulumi.Input[_builtins.str]]
-        """
-        Group ID that will have permission to access the Resource.
-        """
-        security_policy_id: NotRequired[pulumi.Input[_builtins.str]]
-        """
-        The ID of a `get_twingate_security_policy` to use as the access policy for the group IDs in the access block. Default is 'Null' which points to `Default Policy` on Admin console.
-        """
-elif False:
-    TwingateResourceAccessGroupArgsDict: TypeAlias = Mapping[str, Any]
+class TwingateResourceAccessGroupArgsDict(TypedDict):
+    access_policies: NotRequired[pulumi.Input[Sequence[pulumi.Input['TwingateResourceAccessGroupAccessPolicyArgsDict']]]]
+    """
+    Restrict access according to JIT access policy
+    """
+    group_id: NotRequired[pulumi.Input[_builtins.str]]
+    """
+    Group ID that will have permission to access the Resource.
+    """
+    security_policy_id: NotRequired[pulumi.Input[_builtins.str]]
+    """
+    The ID of a `get_twingate_security_policy` to use as the access policy for the group IDs in the access block. Default is 'Null' which points to `Default Policy` on Admin console.
+    """
 
 @pulumi.input_type
 class TwingateResourceAccessGroupArgs:
@@ -1147,22 +1115,19 @@ class TwingateResourceAccessGroupArgs:
         pulumi.set(self, "security_policy_id", value)
 
 
-if not MYPY:
-    class TwingateResourceAccessGroupAccessPolicyArgsDict(TypedDict):
-        approval_mode: NotRequired[pulumi.Input[_builtins.str]]
-        """
-        This will set the approval model on the edge. The valid values are `AUTOMATIC` and `MANUAL`.
-        """
-        duration: NotRequired[pulumi.Input[_builtins.str]]
-        """
-        This will set the access duration on the edge. Duration must be between 1 hour and 365 days. The valid values are like `1h` and `2d`.
-        """
-        mode: NotRequired[pulumi.Input[_builtins.str]]
-        """
-        This will set the access_policy mode on the edge. The valid values are `MANUAL`, `AUTO_LOCK` and `ACCESS_REQUEST`.
-        """
-elif False:
-    TwingateResourceAccessGroupAccessPolicyArgsDict: TypeAlias = Mapping[str, Any]
+class TwingateResourceAccessGroupAccessPolicyArgsDict(TypedDict):
+    approval_mode: NotRequired[pulumi.Input[_builtins.str]]
+    """
+    This will set the approval model on the edge. The valid values are `AUTOMATIC` and `MANUAL`.
+    """
+    duration: NotRequired[pulumi.Input[_builtins.str]]
+    """
+    This will set the access duration on the edge. Duration must be between 1 hour and 365 days. The valid values are like `1h` and `2d`.
+    """
+    mode: NotRequired[pulumi.Input[_builtins.str]]
+    """
+    This will set the access_policy mode on the edge. The valid values are `MANUAL`, `AUTO_LOCK` and `ACCESS_REQUEST`.
+    """
 
 @pulumi.input_type
 class TwingateResourceAccessGroupAccessPolicyArgs:
@@ -1219,22 +1184,19 @@ class TwingateResourceAccessGroupAccessPolicyArgs:
         pulumi.set(self, "mode", value)
 
 
-if not MYPY:
-    class TwingateResourceAccessPolicyArgsDict(TypedDict):
-        approval_mode: NotRequired[pulumi.Input[_builtins.str]]
-        """
-        This will set the approval model on the edge. The valid values are `AUTOMATIC` and `MANUAL`.
-        """
-        duration: NotRequired[pulumi.Input[_builtins.str]]
-        """
-        This will set the access duration on the edge. Duration must be between 1 hour and 365 days. The valid values are like `1h` and `2d`.
-        """
-        mode: NotRequired[pulumi.Input[_builtins.str]]
-        """
-        This will set the access_policy mode on the edge. The valid values are `MANUAL`, `AUTO_LOCK` and `ACCESS_REQUEST`.
-        """
-elif False:
-    TwingateResourceAccessPolicyArgsDict: TypeAlias = Mapping[str, Any]
+class TwingateResourceAccessPolicyArgsDict(TypedDict):
+    approval_mode: NotRequired[pulumi.Input[_builtins.str]]
+    """
+    This will set the approval model on the edge. The valid values are `AUTOMATIC` and `MANUAL`.
+    """
+    duration: NotRequired[pulumi.Input[_builtins.str]]
+    """
+    This will set the access duration on the edge. Duration must be between 1 hour and 365 days. The valid values are like `1h` and `2d`.
+    """
+    mode: NotRequired[pulumi.Input[_builtins.str]]
+    """
+    This will set the access_policy mode on the edge. The valid values are `MANUAL`, `AUTO_LOCK` and `ACCESS_REQUEST`.
+    """
 
 @pulumi.input_type
 class TwingateResourceAccessPolicyArgs:
@@ -1291,14 +1253,11 @@ class TwingateResourceAccessPolicyArgs:
         pulumi.set(self, "mode", value)
 
 
-if not MYPY:
-    class TwingateResourceAccessServiceArgsDict(TypedDict):
-        service_account_id: NotRequired[pulumi.Input[_builtins.str]]
-        """
-        The ID of the service account that should have access to this Resource.
-        """
-elif False:
-    TwingateResourceAccessServiceArgsDict: TypeAlias = Mapping[str, Any]
+class TwingateResourceAccessServiceArgsDict(TypedDict):
+    service_account_id: NotRequired[pulumi.Input[_builtins.str]]
+    """
+    The ID of the service account that should have access to this Resource.
+    """
 
 @pulumi.input_type
 class TwingateResourceAccessServiceArgs:
@@ -1323,16 +1282,13 @@ class TwingateResourceAccessServiceArgs:
         pulumi.set(self, "service_account_id", value)
 
 
-if not MYPY:
-    class TwingateResourceProtocolsArgsDict(TypedDict):
-        allow_icmp: NotRequired[pulumi.Input[_builtins.bool]]
-        """
-        Whether to allow ICMP (ping) traffic
-        """
-        tcp: NotRequired[pulumi.Input['TwingateResourceProtocolsTcpArgsDict']]
-        udp: NotRequired[pulumi.Input['TwingateResourceProtocolsUdpArgsDict']]
-elif False:
-    TwingateResourceProtocolsArgsDict: TypeAlias = Mapping[str, Any]
+class TwingateResourceProtocolsArgsDict(TypedDict):
+    allow_icmp: NotRequired[pulumi.Input[_builtins.bool]]
+    """
+    Whether to allow ICMP (ping) traffic
+    """
+    tcp: NotRequired[pulumi.Input['TwingateResourceProtocolsTcpArgsDict']]
+    udp: NotRequired[pulumi.Input['TwingateResourceProtocolsUdpArgsDict']]
 
 @pulumi.input_type
 class TwingateResourceProtocolsArgs:
@@ -1381,18 +1337,15 @@ class TwingateResourceProtocolsArgs:
         pulumi.set(self, "udp", value)
 
 
-if not MYPY:
-    class TwingateResourceProtocolsTcpArgsDict(TypedDict):
-        policy: NotRequired[pulumi.Input[_builtins.str]]
-        """
-        Whether to allow or deny all ports, or restrict protocol access within certain port ranges: Can be `RESTRICTED` (only listed ports are allowed), `ALLOW_ALL`, or `DENY_ALL`
-        """
-        ports: NotRequired[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]]
-        """
-        List of port ranges between 1 and 65535 inclusive, in the format `100-200` for a range, or `8080` for a single port
-        """
-elif False:
-    TwingateResourceProtocolsTcpArgsDict: TypeAlias = Mapping[str, Any]
+class TwingateResourceProtocolsTcpArgsDict(TypedDict):
+    policy: NotRequired[pulumi.Input[_builtins.str]]
+    """
+    Whether to allow or deny all ports, or restrict protocol access within certain port ranges: Can be `RESTRICTED` (only listed ports are allowed), `ALLOW_ALL`, or `DENY_ALL`
+    """
+    ports: NotRequired[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]]
+    """
+    List of port ranges between 1 and 65535 inclusive, in the format `100-200` for a range, or `8080` for a single port
+    """
 
 @pulumi.input_type
 class TwingateResourceProtocolsTcpArgs:
@@ -1433,18 +1386,15 @@ class TwingateResourceProtocolsTcpArgs:
         pulumi.set(self, "ports", value)
 
 
-if not MYPY:
-    class TwingateResourceProtocolsUdpArgsDict(TypedDict):
-        policy: NotRequired[pulumi.Input[_builtins.str]]
-        """
-        Whether to allow or deny all ports, or restrict protocol access within certain port ranges: Can be `RESTRICTED` (only listed ports are allowed), `ALLOW_ALL`, or `DENY_ALL`
-        """
-        ports: NotRequired[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]]
-        """
-        List of port ranges between 1 and 65535 inclusive, in the format `100-200` for a range, or `8080` for a single port
-        """
-elif False:
-    TwingateResourceProtocolsUdpArgsDict: TypeAlias = Mapping[str, Any]
+class TwingateResourceProtocolsUdpArgsDict(TypedDict):
+    policy: NotRequired[pulumi.Input[_builtins.str]]
+    """
+    Whether to allow or deny all ports, or restrict protocol access within certain port ranges: Can be `RESTRICTED` (only listed ports are allowed), `ALLOW_ALL`, or `DENY_ALL`
+    """
+    ports: NotRequired[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]]
+    """
+    List of port ranges between 1 and 65535 inclusive, in the format `100-200` for a range, or `8080` for a single port
+    """
 
 @pulumi.input_type
 class TwingateResourceProtocolsUdpArgs:
@@ -1485,14 +1435,11 @@ class TwingateResourceProtocolsUdpArgs:
         pulumi.set(self, "ports", value)
 
 
-if not MYPY:
-    class GetTwingateDNSFilteringProfileAllowedDomainsArgsDict(TypedDict):
-        domains: Sequence[_builtins.str]
-        """
-        A set of allowed domains.
-        """
-elif False:
-    GetTwingateDNSFilteringProfileAllowedDomainsArgsDict: TypeAlias = Mapping[str, Any]
+class GetTwingateDNSFilteringProfileAllowedDomainsArgsDict(TypedDict):
+    domains: Sequence[_builtins.str]
+    """
+    A set of allowed domains.
+    """
 
 @pulumi.input_type
 class GetTwingateDNSFilteringProfileAllowedDomainsArgs:
@@ -1516,46 +1463,43 @@ class GetTwingateDNSFilteringProfileAllowedDomainsArgs:
         pulumi.set(self, "domains", value)
 
 
-if not MYPY:
-    class GetTwingateDNSFilteringProfileContentCategoriesArgsDict(TypedDict):
-        block_adult_content: _builtins.bool
-        """
-        Whether to block adult content.
-        """
-        block_dating: _builtins.bool
-        """
-        Whether to block dating content.
-        """
-        block_gambling: _builtins.bool
-        """
-        Whether to block gambling content.
-        """
-        block_games: _builtins.bool
-        """
-        Whether to block games.
-        """
-        block_piracy: _builtins.bool
-        """
-        Whether to block piracy sites.
-        """
-        block_social_media: _builtins.bool
-        """
-        Whether to block social media.
-        """
-        block_streaming: _builtins.bool
-        """
-        Whether to block streaming content.
-        """
-        enable_safesearch: _builtins.bool
-        """
-        Whether to force safe search.
-        """
-        enable_youtube_restricted_mode: _builtins.bool
-        """
-        Whether to force YouTube to use restricted mode.
-        """
-elif False:
-    GetTwingateDNSFilteringProfileContentCategoriesArgsDict: TypeAlias = Mapping[str, Any]
+class GetTwingateDNSFilteringProfileContentCategoriesArgsDict(TypedDict):
+    block_adult_content: _builtins.bool
+    """
+    Whether to block adult content.
+    """
+    block_dating: _builtins.bool
+    """
+    Whether to block dating content.
+    """
+    block_gambling: _builtins.bool
+    """
+    Whether to block gambling content.
+    """
+    block_games: _builtins.bool
+    """
+    Whether to block games.
+    """
+    block_piracy: _builtins.bool
+    """
+    Whether to block piracy sites.
+    """
+    block_social_media: _builtins.bool
+    """
+    Whether to block social media.
+    """
+    block_streaming: _builtins.bool
+    """
+    Whether to block streaming content.
+    """
+    enable_safesearch: _builtins.bool
+    """
+    Whether to force safe search.
+    """
+    enable_youtube_restricted_mode: _builtins.bool
+    """
+    Whether to force YouTube to use restricted mode.
+    """
 
 @pulumi.input_type
 class GetTwingateDNSFilteringProfileContentCategoriesArgs:
@@ -1699,14 +1643,11 @@ class GetTwingateDNSFilteringProfileContentCategoriesArgs:
         pulumi.set(self, "enable_youtube_restricted_mode", value)
 
 
-if not MYPY:
-    class GetTwingateDNSFilteringProfileDeniedDomainsArgsDict(TypedDict):
-        domains: Sequence[_builtins.str]
-        """
-        A set of denied domains.
-        """
-elif False:
-    GetTwingateDNSFilteringProfileDeniedDomainsArgsDict: TypeAlias = Mapping[str, Any]
+class GetTwingateDNSFilteringProfileDeniedDomainsArgsDict(TypedDict):
+    domains: Sequence[_builtins.str]
+    """
+    A set of denied domains.
+    """
 
 @pulumi.input_type
 class GetTwingateDNSFilteringProfileDeniedDomainsArgs:
@@ -1730,22 +1671,19 @@ class GetTwingateDNSFilteringProfileDeniedDomainsArgs:
         pulumi.set(self, "domains", value)
 
 
-if not MYPY:
-    class GetTwingateDNSFilteringProfilePrivacyCategoriesArgsDict(TypedDict):
-        block_ads_and_trackers: _builtins.bool
-        """
-        Whether to block ads and trackers.
-        """
-        block_affiliate_links: _builtins.bool
-        """
-        Whether to block affiliate links.
-        """
-        block_disguised_trackers: _builtins.bool
-        """
-        Whether to block disguised third party trackers.
-        """
-elif False:
-    GetTwingateDNSFilteringProfilePrivacyCategoriesArgsDict: TypeAlias = Mapping[str, Any]
+class GetTwingateDNSFilteringProfilePrivacyCategoriesArgsDict(TypedDict):
+    block_ads_and_trackers: _builtins.bool
+    """
+    Whether to block ads and trackers.
+    """
+    block_affiliate_links: _builtins.bool
+    """
+    Whether to block affiliate links.
+    """
+    block_disguised_trackers: _builtins.bool
+    """
+    Whether to block disguised third party trackers.
+    """
 
 @pulumi.input_type
 class GetTwingateDNSFilteringProfilePrivacyCategoriesArgs:
@@ -1799,46 +1737,43 @@ class GetTwingateDNSFilteringProfilePrivacyCategoriesArgs:
         pulumi.set(self, "block_disguised_trackers", value)
 
 
-if not MYPY:
-    class GetTwingateDNSFilteringProfileSecurityCategoriesArgsDict(TypedDict):
-        block_cryptojacking: _builtins.bool
-        """
-        Whether to block cryptojacking sites.
-        """
-        block_dns_rebinding: _builtins.bool
-        """
-        Blocks public DNS entries from returning private IP addresses.
-        """
-        block_domain_generation_algorithms: _builtins.bool
-        """
-        Blocks DGA domains.
-        """
-        block_idn_homoglyph: _builtins.bool
-        """
-        Whether to block homoglyph attacks.
-        """
-        block_newly_registered_domains: _builtins.bool
-        """
-        Blocks newly registered domains.
-        """
-        block_parked_domains: _builtins.bool
-        """
-        Block parked domains.
-        """
-        block_typosquatting: _builtins.bool
-        """
-        Blocks typosquatted domains.
-        """
-        enable_google_safe_browsing: _builtins.bool
-        """
-        Whether to use Google Safe browsing lists to block content.
-        """
-        enable_threat_intelligence_feeds: _builtins.bool
-        """
-        Whether to filter content using threat intelligence feeds.
-        """
-elif False:
-    GetTwingateDNSFilteringProfileSecurityCategoriesArgsDict: TypeAlias = Mapping[str, Any]
+class GetTwingateDNSFilteringProfileSecurityCategoriesArgsDict(TypedDict):
+    block_cryptojacking: _builtins.bool
+    """
+    Whether to block cryptojacking sites.
+    """
+    block_dns_rebinding: _builtins.bool
+    """
+    Blocks public DNS entries from returning private IP addresses.
+    """
+    block_domain_generation_algorithms: _builtins.bool
+    """
+    Blocks DGA domains.
+    """
+    block_idn_homoglyph: _builtins.bool
+    """
+    Whether to block homoglyph attacks.
+    """
+    block_newly_registered_domains: _builtins.bool
+    """
+    Blocks newly registered domains.
+    """
+    block_parked_domains: _builtins.bool
+    """
+    Block parked domains.
+    """
+    block_typosquatting: _builtins.bool
+    """
+    Blocks typosquatted domains.
+    """
+    enable_google_safe_browsing: _builtins.bool
+    """
+    Whether to use Google Safe browsing lists to block content.
+    """
+    enable_threat_intelligence_feeds: _builtins.bool
+    """
+    Whether to filter content using threat intelligence feeds.
+    """
 
 @pulumi.input_type
 class GetTwingateDNSFilteringProfileSecurityCategoriesArgs:
@@ -1982,16 +1917,13 @@ class GetTwingateDNSFilteringProfileSecurityCategoriesArgs:
         pulumi.set(self, "enable_threat_intelligence_feeds", value)
 
 
-if not MYPY:
-    class GetTwingateResourceProtocolsArgsDict(TypedDict):
-        allow_icmp: _builtins.bool
-        """
-        Whether to allow ICMP (ping) traffic
-        """
-        tcp: NotRequired['GetTwingateResourceProtocolsTcpArgsDict']
-        udp: NotRequired['GetTwingateResourceProtocolsUdpArgsDict']
-elif False:
-    GetTwingateResourceProtocolsArgsDict: TypeAlias = Mapping[str, Any]
+class GetTwingateResourceProtocolsArgsDict(TypedDict):
+    allow_icmp: _builtins.bool
+    """
+    Whether to allow ICMP (ping) traffic
+    """
+    tcp: NotRequired['GetTwingateResourceProtocolsTcpArgsDict']
+    udp: NotRequired['GetTwingateResourceProtocolsUdpArgsDict']
 
 @pulumi.input_type
 class GetTwingateResourceProtocolsArgs:
@@ -2039,18 +1971,15 @@ class GetTwingateResourceProtocolsArgs:
         pulumi.set(self, "udp", value)
 
 
-if not MYPY:
-    class GetTwingateResourceProtocolsTcpArgsDict(TypedDict):
-        policy: _builtins.str
-        """
-        Whether to allow or deny all ports, or restrict protocol access within certain port ranges: Can be `RESTRICTED` (only listed ports are allowed), `ALLOW_ALL`, or `DENY_ALL`
-        """
-        ports: Sequence[_builtins.str]
-        """
-        List of port ranges between 1 and 65535 inclusive, in the format `100-200` for a range, or `8080` for a single port
-        """
-elif False:
-    GetTwingateResourceProtocolsTcpArgsDict: TypeAlias = Mapping[str, Any]
+class GetTwingateResourceProtocolsTcpArgsDict(TypedDict):
+    policy: _builtins.str
+    """
+    Whether to allow or deny all ports, or restrict protocol access within certain port ranges: Can be `RESTRICTED` (only listed ports are allowed), `ALLOW_ALL`, or `DENY_ALL`
+    """
+    ports: Sequence[_builtins.str]
+    """
+    List of port ranges between 1 and 65535 inclusive, in the format `100-200` for a range, or `8080` for a single port
+    """
 
 @pulumi.input_type
 class GetTwingateResourceProtocolsTcpArgs:
@@ -2089,18 +2018,15 @@ class GetTwingateResourceProtocolsTcpArgs:
         pulumi.set(self, "ports", value)
 
 
-if not MYPY:
-    class GetTwingateResourceProtocolsUdpArgsDict(TypedDict):
-        policy: _builtins.str
-        """
-        Whether to allow or deny all ports, or restrict protocol access within certain port ranges: Can be `RESTRICTED` (only listed ports are allowed), `ALLOW_ALL`, or `DENY_ALL`
-        """
-        ports: Sequence[_builtins.str]
-        """
-        List of port ranges between 1 and 65535 inclusive, in the format `100-200` for a range, or `8080` for a single port
-        """
-elif False:
-    GetTwingateResourceProtocolsUdpArgsDict: TypeAlias = Mapping[str, Any]
+class GetTwingateResourceProtocolsUdpArgsDict(TypedDict):
+    policy: _builtins.str
+    """
+    Whether to allow or deny all ports, or restrict protocol access within certain port ranges: Can be `RESTRICTED` (only listed ports are allowed), `ALLOW_ALL`, or `DENY_ALL`
+    """
+    ports: Sequence[_builtins.str]
+    """
+    List of port ranges between 1 and 65535 inclusive, in the format `100-200` for a range, or `8080` for a single port
+    """
 
 @pulumi.input_type
 class GetTwingateResourceProtocolsUdpArgs:

--- a/sdk/python/pulumi_twingate/_utilities.py
+++ b/sdk/python/pulumi_twingate/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/pulumi_twingate/provider.py
+++ b/sdk/python/pulumi_twingate/provider.py
@@ -29,6 +29,7 @@ class ProviderArgs:
                  url: Optional[pulumi.Input[_builtins.str]] = None):
         """
         The set of arguments for constructing a Provider resource.
+
         :param pulumi.Input[_builtins.str] api_token: The access key for API operations. You can retrieve this
                from the Twingate Admin Console ([documentation](https://docs.twingate.com/docs/api-overview)).
                Alternatively, this can be specified using the TWINGATE_API_TOKEN environment variable.
@@ -173,6 +174,7 @@ class Provider(pulumi.ProviderResource):
         construction to achieve fine-grained programmatic control over provider settings. See the
         [documentation](https://www.pulumi.com/docs/reference/programming-model/#providers) for more information.
 
+
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[_builtins.str] api_token: The access key for API operations. You can retrieve this
@@ -202,6 +204,7 @@ class Provider(pulumi.ProviderResource):
         settings, however an explicit `Provider` instance may be created and passed during resource
         construction to achieve fine-grained programmatic control over provider settings. See the
         [documentation](https://www.pulumi.com/docs/reference/programming-model/#providers) for more information.
+
 
         :param str resource_name: The name of the resource.
         :param ProviderArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/pulumi_twingate/twingate_connector.py
+++ b/sdk/python/pulumi_twingate/twingate_connector.py
@@ -24,6 +24,7 @@ class TwingateConnectorArgs:
                  status_updates_enabled: Optional[pulumi.Input[_builtins.bool]] = None):
         """
         The set of arguments for constructing a TwingateConnector resource.
+
         :param pulumi.Input[_builtins.str] remote_network_id: The ID of the Remote Network the Connector is attached to.
         :param pulumi.Input[_builtins.str] name: Name of the Connector, if not provided one will be generated.
         :param pulumi.Input[_builtins.bool] status_updates_enabled: Determines whether status notifications are enabled for the Connector. Default is `true`.
@@ -84,6 +85,7 @@ class _TwingateConnectorState:
                  version: Optional[pulumi.Input[_builtins.str]] = None):
         """
         Input properties used for looking up and filtering TwingateConnector resources.
+
         :param pulumi.Input[_builtins.str] hostname: The hostname of the machine hosting the Connector.
         :param pulumi.Input[_builtins.str] name: Name of the Connector, if not provided one will be generated.
         :param pulumi.Input[Sequence[pulumi.Input[_builtins.str]]] private_ips: The Connector's private IP addresses.
@@ -238,6 +240,7 @@ class TwingateConnector(pulumi.CustomResource):
         $ pulumi import twingate:index/twingateConnector:TwingateConnector aws_connector Q29ubmVjdG9yOjI2NzM=
         ```
 
+
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[_builtins.str] name: Name of the Connector, if not provided one will be generated.
@@ -270,6 +273,7 @@ class TwingateConnector(pulumi.CustomResource):
         ```sh
         $ pulumi import twingate:index/twingateConnector:TwingateConnector aws_connector Q29ubmVjdG9yOjI2NzM=
         ```
+
 
         :param str resource_name: The name of the resource.
         :param TwingateConnectorArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/pulumi_twingate/twingate_connector_tokens.py
+++ b/sdk/python/pulumi_twingate/twingate_connector_tokens.py
@@ -23,6 +23,7 @@ class TwingateConnectorTokensArgs:
                  keepers: Optional[pulumi.Input[Mapping[str, pulumi.Input[_builtins.str]]]] = None):
         """
         The set of arguments for constructing a TwingateConnectorTokens resource.
+
         :param pulumi.Input[_builtins.str] connector_id: The ID of the parent Connector
         :param pulumi.Input[Mapping[str, pulumi.Input[_builtins.str]]] keepers: Arbitrary map of values that, when changed, will trigger recreation of resource. Use this to automatically rotate Connector tokens on a schedule.
         """
@@ -64,6 +65,7 @@ class _TwingateConnectorTokensState:
                  refresh_token: Optional[pulumi.Input[_builtins.str]] = None):
         """
         Input properties used for looking up and filtering TwingateConnectorTokens resources.
+
         :param pulumi.Input[_builtins.str] access_token: The Access Token of the parent Connector
         :param pulumi.Input[_builtins.str] connector_id: The ID of the parent Connector
         :param pulumi.Input[Mapping[str, pulumi.Input[_builtins.str]]] keepers: Arbitrary map of values that, when changed, will trigger recreation of resource. Use this to automatically rotate Connector tokens on a schedule.
@@ -150,6 +152,7 @@ class TwingateConnectorTokens(pulumi.CustomResource):
         aws_connector_tokens = twingate.TwingateConnectorTokens("aws_connector_tokens", connector_id=aws_connector.id)
         ```
 
+
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[_builtins.str] connector_id: The ID of the parent Connector
@@ -174,6 +177,7 @@ class TwingateConnectorTokens(pulumi.CustomResource):
         aws_connector = twingate.TwingateConnector("aws_connector", remote_network_id=aws_network.id)
         aws_connector_tokens = twingate.TwingateConnectorTokens("aws_connector_tokens", connector_id=aws_connector.id)
         ```
+
 
         :param str resource_name: The name of the resource.
         :param TwingateConnectorTokensArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/pulumi_twingate/twingate_dns_filtering_profile.py
+++ b/sdk/python/pulumi_twingate/twingate_dns_filtering_profile.py
@@ -32,6 +32,7 @@ class TwingateDNSFilteringProfileArgs:
                  security_categories: Optional[pulumi.Input['TwingateDNSFilteringProfileSecurityCategoriesArgs']] = None):
         """
         The set of arguments for constructing a TwingateDNSFilteringProfile resource.
+
         :param pulumi.Input[_builtins.float] priority: A floating point number representing the profile's priority.
         :param pulumi.Input['TwingateDNSFilteringProfileAllowedDomainsArgs'] allowed_domains: A block with the following attributes.
         :param pulumi.Input['TwingateDNSFilteringProfileContentCategoriesArgs'] content_categories: A block with the following attributes.
@@ -183,6 +184,7 @@ class _TwingateDNSFilteringProfileState:
                  security_categories: Optional[pulumi.Input['TwingateDNSFilteringProfileSecurityCategoriesArgs']] = None):
         """
         Input properties used for looking up and filtering TwingateDNSFilteringProfile resources.
+
         :param pulumi.Input['TwingateDNSFilteringProfileAllowedDomainsArgs'] allowed_domains: A block with the following attributes.
         :param pulumi.Input['TwingateDNSFilteringProfileContentCategoriesArgs'] content_categories: A block with the following attributes.
         :param pulumi.Input['TwingateDNSFilteringProfileDeniedDomainsArgs'] denied_domains: A block with the following attributes.
@@ -384,6 +386,7 @@ class TwingateDNSFilteringProfile(pulumi.CustomResource):
         $ pulumi import twingate:index/twingateDNSFilteringProfile:TwingateDNSFilteringProfile example RG5zRmlsdGVyaW5nUHJvZmlsZToxY2I4YzM0YTc0
         ```
 
+
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[Union['TwingateDNSFilteringProfileAllowedDomainsArgs', 'TwingateDNSFilteringProfileAllowedDomainsArgsDict']] allowed_domains: A block with the following attributes.
@@ -448,6 +451,7 @@ class TwingateDNSFilteringProfile(pulumi.CustomResource):
         ```sh
         $ pulumi import twingate:index/twingateDNSFilteringProfile:TwingateDNSFilteringProfile example RG5zRmlsdGVyaW5nUHJvZmlsZToxY2I4YzM0YTc0
         ```
+
 
         :param str resource_name: The name of the resource.
         :param TwingateDNSFilteringProfileArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/pulumi_twingate/twingate_group.py
+++ b/sdk/python/pulumi_twingate/twingate_group.py
@@ -24,6 +24,7 @@ class TwingateGroupArgs:
                  user_ids: Optional[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]] = None):
         """
         The set of arguments for constructing a TwingateGroup resource.
+
         :param pulumi.Input[_builtins.bool] is_authoritative: Determines whether User assignments to this Group will override any existing assignments. Default is `true`. If set to `false`, assignments made outside of Terraform will be ignored.
         :param pulumi.Input[_builtins.str] name: The name of the group
         :param pulumi.Input[Sequence[pulumi.Input[_builtins.str]]] user_ids: List of User IDs that have permission to access the Group.
@@ -80,6 +81,7 @@ class _TwingateGroupState:
                  user_ids: Optional[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]] = None):
         """
         Input properties used for looking up and filtering TwingateGroup resources.
+
         :param pulumi.Input[_builtins.bool] is_authoritative: Determines whether User assignments to this Group will override any existing assignments. Default is `true`. If set to `false`, assignments made outside of Terraform will be ignored.
         :param pulumi.Input[_builtins.str] name: The name of the group
         :param pulumi.Input[Sequence[pulumi.Input[_builtins.str]]] user_ids: List of User IDs that have permission to access the Group.
@@ -156,6 +158,7 @@ class TwingateGroup(pulumi.CustomResource):
         $ pulumi import twingate:index/twingateGroup:TwingateGroup aws R3JvdXA6MzQ4OTE=
         ```
 
+
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[_builtins.bool] is_authoritative: Determines whether User assignments to this Group will override any existing assignments. Default is `true`. If set to `false`, assignments made outside of Terraform will be ignored.
@@ -185,6 +188,7 @@ class TwingateGroup(pulumi.CustomResource):
         ```sh
         $ pulumi import twingate:index/twingateGroup:TwingateGroup aws R3JvdXA6MzQ4OTE=
         ```
+
 
         :param str resource_name: The name of the resource.
         :param TwingateGroupArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/pulumi_twingate/twingate_remote_network.py
+++ b/sdk/python/pulumi_twingate/twingate_remote_network.py
@@ -24,6 +24,7 @@ class TwingateRemoteNetworkArgs:
                  type: Optional[pulumi.Input[_builtins.str]] = None):
         """
         The set of arguments for constructing a TwingateRemoteNetwork resource.
+
         :param pulumi.Input[_builtins.str] location: The location of the Remote Network. Must be one of the following: AWS, AZURE, GOOGLE*CLOUD, ON*PREMISE, OTHER.
         :param pulumi.Input[_builtins.str] name: The name of the Remote Network
         :param pulumi.Input[_builtins.str] type: The type of the Remote Network. Must be one of the following: REGULAR, EXIT. Defaults to REGULAR.
@@ -80,6 +81,7 @@ class _TwingateRemoteNetworkState:
                  type: Optional[pulumi.Input[_builtins.str]] = None):
         """
         Input properties used for looking up and filtering TwingateRemoteNetwork resources.
+
         :param pulumi.Input[_builtins.str] location: The location of the Remote Network. Must be one of the following: AWS, AZURE, GOOGLE*CLOUD, ON*PREMISE, OTHER.
         :param pulumi.Input[_builtins.str] name: The name of the Remote Network
         :param pulumi.Input[_builtins.str] type: The type of the Remote Network. Must be one of the following: REGULAR, EXIT. Defaults to REGULAR.
@@ -156,6 +158,7 @@ class TwingateRemoteNetwork(pulumi.CustomResource):
         $ pulumi import twingate:index/twingateRemoteNetwork:TwingateRemoteNetwork network UmVtb3RlTmV0d29zaipgMKIkNg==
         ```
 
+
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[_builtins.str] location: The location of the Remote Network. Must be one of the following: AWS, AZURE, GOOGLE*CLOUD, ON*PREMISE, OTHER.
@@ -185,6 +188,7 @@ class TwingateRemoteNetwork(pulumi.CustomResource):
         ```sh
         $ pulumi import twingate:index/twingateRemoteNetwork:TwingateRemoteNetwork network UmVtb3RlTmV0d29zaipgMKIkNg==
         ```
+
 
         :param str resource_name: The name of the resource.
         :param TwingateRemoteNetworkArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/pulumi_twingate/twingate_resource.py
+++ b/sdk/python/pulumi_twingate/twingate_resource.py
@@ -37,6 +37,7 @@ class TwingateResourceArgs:
                  tags: Optional[pulumi.Input[Mapping[str, pulumi.Input[_builtins.str]]]] = None):
         """
         The set of arguments for constructing a TwingateResource resource.
+
         :param pulumi.Input[_builtins.str] address: The Resource's IP/CIDR or FQDN/DNS zone
         :param pulumi.Input[_builtins.str] remote_network_id: Remote Network ID where the Resource lives
         :param pulumi.Input[Sequence[pulumi.Input['TwingateResourceAccessGroupArgs']]] access_groups: Restrict access to certain group
@@ -268,6 +269,7 @@ class _TwingateResourceState:
                  tags_all: Optional[pulumi.Input[Mapping[str, pulumi.Input[_builtins.str]]]] = None):
         """
         Input properties used for looking up and filtering TwingateResource resources.
+
         :param pulumi.Input[Sequence[pulumi.Input['TwingateResourceAccessGroupArgs']]] access_groups: Restrict access to certain group
         :param pulumi.Input[Sequence[pulumi.Input['TwingateResourceAccessPolicyArgs']]] access_policies: Restrict access according to JIT access policy
         :param pulumi.Input[Sequence[pulumi.Input['TwingateResourceAccessServiceArgs']]] access_services: Restrict access to certain service account
@@ -526,6 +528,7 @@ class TwingateResource(pulumi.CustomResource):
         $ pulumi import twingate:index/twingateResource:TwingateResource resource UmVzb3VyY2U6MzQwNDQ3
         ```
 
+
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[Sequence[pulumi.Input[Union['TwingateResourceAccessGroupArgs', 'TwingateResourceAccessGroupArgsDict']]]] access_groups: Restrict access to certain group
@@ -557,6 +560,7 @@ class TwingateResource(pulumi.CustomResource):
         ```sh
         $ pulumi import twingate:index/twingateResource:TwingateResource resource UmVzb3VyY2U6MzQwNDQ3
         ```
+
 
         :param str resource_name: The name of the resource.
         :param TwingateResourceArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/pulumi_twingate/twingate_service_account.py
+++ b/sdk/python/pulumi_twingate/twingate_service_account.py
@@ -22,6 +22,7 @@ class TwingateServiceAccountArgs:
                  name: Optional[pulumi.Input[_builtins.str]] = None):
         """
         The set of arguments for constructing a TwingateServiceAccount resource.
+
         :param pulumi.Input[_builtins.str] name: The name of the Service Account in Twingate
         """
         if name is not None:
@@ -46,6 +47,7 @@ class _TwingateServiceAccountState:
                  name: Optional[pulumi.Input[_builtins.str]] = None):
         """
         Input properties used for looking up and filtering TwingateServiceAccount resources.
+
         :param pulumi.Input[_builtins.str] name: The name of the Service Account in Twingate
         """
         if name is not None:
@@ -84,6 +86,7 @@ class TwingateServiceAccount(pulumi.CustomResource):
         github_actions_prod = twingate.TwingateServiceAccount("github_actions_prod", name="Github Actions PROD")
         ```
 
+
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[_builtins.str] name: The name of the Service Account in Twingate
@@ -105,6 +108,7 @@ class TwingateServiceAccount(pulumi.CustomResource):
 
         github_actions_prod = twingate.TwingateServiceAccount("github_actions_prod", name="Github Actions PROD")
         ```
+
 
         :param str resource_name: The name of the resource.
         :param TwingateServiceAccountArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/pulumi_twingate/twingate_service_account_key.py
+++ b/sdk/python/pulumi_twingate/twingate_service_account_key.py
@@ -24,6 +24,7 @@ class TwingateServiceAccountKeyArgs:
                  name: Optional[pulumi.Input[_builtins.str]] = None):
         """
         The set of arguments for constructing a TwingateServiceAccountKey resource.
+
         :param pulumi.Input[_builtins.str] service_account_id: The id of the Service Account
         :param pulumi.Input[_builtins.int] expiration_time: Specifies how many days until a Service Account Key expires. This should be an integer between 0 and 365 representing the number of days until the Service Account Key will expire. Defaults to 0, meaning the key will never expire.
         :param pulumi.Input[_builtins.str] name: The name of the Service Key
@@ -81,6 +82,7 @@ class _TwingateServiceAccountKeyState:
                  token: Optional[pulumi.Input[_builtins.str]] = None):
         """
         Input properties used for looking up and filtering TwingateServiceAccountKey resources.
+
         :param pulumi.Input[_builtins.int] expiration_time: Specifies how many days until a Service Account Key expires. This should be an integer between 0 and 365 representing the number of days until the Service Account Key will expire. Defaults to 0, meaning the key will never expire.
         :param pulumi.Input[_builtins.bool] is_active: If the value of this attribute changes to false, Terraform will destroy and recreate the resource.
         :param pulumi.Input[_builtins.str] name: The name of the Service Key
@@ -172,6 +174,7 @@ class TwingateServiceAccountKey(pulumi.CustomResource):
         """
         A Service Key authorizes access to all Resources assigned to a Service Account.
 
+
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[_builtins.int] expiration_time: Specifies how many days until a Service Account Key expires. This should be an integer between 0 and 365 representing the number of days until the Service Account Key will expire. Defaults to 0, meaning the key will never expire.
@@ -186,6 +189,7 @@ class TwingateServiceAccountKey(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         A Service Key authorizes access to all Resources assigned to a Service Account.
+
 
         :param str resource_name: The name of the resource.
         :param TwingateServiceAccountKeyArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/pulumi_twingate/twingate_user.py
+++ b/sdk/python/pulumi_twingate/twingate_user.py
@@ -27,6 +27,7 @@ class TwingateUserArgs:
                  send_invite: Optional[pulumi.Input[_builtins.bool]] = None):
         """
         The set of arguments for constructing a TwingateUser resource.
+
         :param pulumi.Input[_builtins.str] email: The User's email address
         :param pulumi.Input[_builtins.str] first_name: The User's first name
         :param pulumi.Input[_builtins.bool] is_active: Determines whether the User is active or not. Inactive users will be not able to sign in.
@@ -135,6 +136,7 @@ class _TwingateUserState:
                  type: Optional[pulumi.Input[_builtins.str]] = None):
         """
         Input properties used for looking up and filtering TwingateUser resources.
+
         :param pulumi.Input[_builtins.str] email: The User's email address
         :param pulumi.Input[_builtins.str] first_name: The User's first name
         :param pulumi.Input[_builtins.bool] is_active: Determines whether the User is active or not. Inactive users will be not able to sign in.
@@ -282,6 +284,7 @@ class TwingateUser(pulumi.CustomResource):
         $ pulumi import twingate:index/twingateUser:TwingateUser user VXNlcjo1ODk3MTM=
         ```
 
+
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[_builtins.str] email: The User's email address
@@ -318,6 +321,7 @@ class TwingateUser(pulumi.CustomResource):
         ```sh
         $ pulumi import twingate:index/twingateUser:TwingateUser user VXNlcjo1ODk3MTM=
         ```
+
 
         :param str resource_name: The name of the resource.
         :param TwingateUserArgs args: The arguments to use to populate this resource's properties.


### PR DESCRIPTION
If you import a TwingateResource, you end up with a persistent diff on tags_all. This marks it as a computed property to resolve that issue. 

I split the generated files into a separate commit since they largely appear unrelated, so you can decide whether you still want them or rebuild those yourselves.