### PR TITLE
chore: add generate_sdks Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ prepare::
 		find ./ ! -path './.git/*' -type f -exec sed -i '' 's/[x]yz/${NAME}/g' {} \; &> /dev/null; \
 	fi
 
-.PHONY: development provider build_sdks build_nodejs build_dotnet build_go build_python cleanup
+.PHONY: development provider build_sdks generate_sdks build_nodejs build_dotnet build_go build_python cleanup
 
 development:: install_plugins provider lint_provider build_sdks install_sdks cleanup # Build the provider & SDKs for a development environment
 
@@ -58,6 +58,9 @@ provider:: tfgen install_plugins # build the provider binary
 	(cd provider && go build -o $(WORKING_DIR)/bin/${PROVIDER} -ldflags "-X ${PROJECT}/${VERSION_PATH}=${VERSION}" ${PROJECT}/${PROVIDER_PATH}/cmd/${PROVIDER})
 
 build_sdks:: install_plugins provider build_nodejs build_python build_go build_dotnet # build all the sdks
+
+# Alias expected by pulumi/upgrade-provider (it runs `make tfgen` then `make generate_sdks`).
+generate_sdks:: build_sdks # generate + build all the sdks
 
 build_nodejs:: VERSION := $(shell pulumictl get version --language javascript --omit-commit-hash)
 build_nodejs:: install_plugins tfgen # build the node sdk


### PR DESCRIPTION
## Changes
- Add a `generate_sdks` Makefile target as an alias to `build_sdks`.

## Why
`pulumi/upgrade-provider` runs `make tfgen` followed by `make generate_sdks`, but this repo only defined `build_sdks`. The tool failed with:

```
make: *** No rule to make target `generate_sdks'.  Stop.
```

Adding the alias makes `upgrade-provider` runs (e.g. the terraform-provider bump) complete without a tool patch. `build_sdks` already depends on `tfgen`/`provider`, so the alias both generates and builds the SDKs.